### PR TITLE
fix libsvm.cwrap is not a function in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ svm.o: libsvm/svm.cpp libsvm/svm.h
 	$(CXX) $(CFLAGS) -c libsvm/svm.cpp -o svm.o
 
 wasm: js-interfaces.c svm.o libsvm/svm.h
-	mkdir -p $(BUILD_DIR)/wasm; $(CC) $(CFLAGS) js-interfaces.c svm.o -o $(BUILD_DIR)/wasm/libsvm.js --pre-js src/wasmPreJS.js -s -s BINARYEN_ASYNC_COMPILATION=1 -s BINARYEN=1 -s "BINARYEN_METHOD='native-wasm'" -s ALLOW_MEMORY_GROWTH=1 -s EXPORTED_FUNCTIONS=$(EXPORTED_FUNCTIONS)
+	mkdir -p $(BUILD_DIR)/wasm; $(CC) $(CFLAGS) js-interfaces.c svm.o -o $(BUILD_DIR)/wasm/libsvm.js --pre-js src/wasmPreJS.js -s -s BINARYEN_ASYNC_COMPILATION=1 -s BINARYEN=1 -s "BINARYEN_METHOD='native-wasm'" -s ALLOW_MEMORY_GROWTH=1 -s EXPORTED_FUNCTIONS=$(EXPORTED_FUNCTIONS)  -s EXTRA_EXPORTED_RUNTIME_METHODS='["cwrap"]'
 
 asm: js-interfaces.c svm.o libsvm/svm.h
-	mkdir -p $(BUILD_DIR)/asm; $(CC) $(CFLAGS) js-interfaces.c svm.o -o $(BUILD_DIR)/asm/libsvm.js --pre-js src/asmPreJS.js -s ALLOW_MEMORY_GROWTH=1 -s EXPORTED_FUNCTIONS=$(EXPORTED_FUNCTIONS)
+	mkdir -p $(BUILD_DIR)/asm; $(CC) $(CFLAGS) js-interfaces.c svm.o -o $(BUILD_DIR)/asm/libsvm.js --pre-js src/asmPreJS.js -s ALLOW_MEMORY_GROWTH=1 -s EXPORTED_FUNCTIONS=$(EXPORTED_FUNCTIONS)   -s EXTRA_EXPORTED_RUNTIME_METHODS='["cwrap"]'
 
 clean:
 	rm -f *~ js-interfaces.o ./svm.o


### PR DESCRIPTION
Fix missing function from browser by adding flags to include cwrap in the Makefile